### PR TITLE
Add start script to package.json for easier app startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "mini-lms",
   "version": "1.0.0",
   "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
   "dependencies": {
     "ejs": "^3.1.10",
     "express": "^4.21.2",


### PR DESCRIPTION
This PR adds a "start" script to package.json so that the app can be started using `npm start` instead of manually running `node app.js`. This improves usability and aligns with standard Node.js project practices.

Tested locally: App runs as expected via `npm start`.
